### PR TITLE
Colour palette

### DIFF
--- a/src/lib/atoms/Debug.svelte
+++ b/src/lib/atoms/Debug.svelte
@@ -9,7 +9,6 @@
 <div
 	bind:clientWidth={width}
 	bind:clientHeight={height}
-	style="background: linear-gradient(150deg, hsl({randomColor1}, 100%, 50%), hsl({randomColor2}, 100%, 50%));"
 >
 	<p>W: {width}px</p>
 	<p>H: {height}px</p>
@@ -17,6 +16,8 @@
 
 <style>
 	div {
+    background: linear-gradient(150deg, var(--color-brown-light) 0%, var(--color-brown) 100%);
+    border: 1px var(--color-brown-dark) solid;
 		display: inline-block;
 		height: 100%;
 		width: 100%;

--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -12,10 +12,10 @@
     text-align: center;
     padding: 0.25rem 0.8rem;
     border-radius: 3rem;
-    border: 2px solid black;
+    border: 2px solid var(--color-brown-dark);
     height: fit-content;
     text-decoration: none;
-    color: black;
+    color: var(--color-brown-dark);
     font-weight: bold;
     width: fit-content;
   }

--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -20,12 +20,12 @@
 
   h2 {
     font-size: 1rem;
-    text-decoration: underline;
+    color: var(--color-brown);
   }
 
   a {
     text-decoration: none;
-    color: black;
+    color: var(--color-brown-dark);
   }
 
   a:hover {

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -37,6 +37,4 @@
   p.name {
     margin-top: 0.25rem;
   }
-
-
 </style>

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -18,7 +18,7 @@
 <style>
   a {
     text-decoration: none;
-    color: black;
+    color: var(--color-brown-dark);
   }
 
   /* This will become img once images are there */

--- a/static/global.css
+++ b/static/global.css
@@ -1,4 +1,14 @@
 :root {
+  --color-brown-light-fallback: #c29f9d;
+  --color-brown-light: hsl(3 23.3% 68.8%);
+
+  --color-brown-fallback: #6d3116;
+  --color-brown: hsl(19 66.4% 25.7%);
+
+  --color-brown-dark-fallback: #3e2518;
+  --color-brown-dark: hsl(21 44.2% 16.9%);
+
+
   --max-width-mobile: 400px;
   --max-width-desktop: 800px;
 }

--- a/static/global.css
+++ b/static/global.css
@@ -19,6 +19,13 @@
   box-sizing: border-box;
 }
 
+body {
+  font-family: 'Roboto', sans-serif;
+  font-size: 16px;
+  line-height: 1.2;
+  color: var(--color-brown-dark);
+}
+
 div.query-container {
   container-type: inline-size;
 }

--- a/static/global.css
+++ b/static/global.css
@@ -1,6 +1,7 @@
 :root {
   --max-width-mobile: 400px;
   --max-width-desktop: 800px;
+}
 
 * {
   margin: 0;

--- a/static/global.css
+++ b/static/global.css
@@ -2,8 +2,11 @@
   --color-brown-light-fallback: #c29f9d;
   --color-brown-light: hsl(3 23.3% 68.8%);
 
-  --color-brown-fallback: #6d3116;
-  --color-brown: hsl(19 66.4% 25.7%);
+  /* --color-brown-fallback: #6d3116;
+  --color-brown: hsl(19 66.4% 25.7%); */
+
+  --color-brown-fallback: #a34a21;
+  --color-brown: hsl(19 66.3% 38.4%);
 
   --color-brown-dark-fallback: #3e2518;
   --color-brown-dark: hsl(21 44.2% 16.9%);


### PR DESCRIPTION
## What does this change?

Closes #38 
Closes #40 
Closes #41

Added colour variables to `global.css` and applied them across the page wherever relevant. Colours were taken from the original website, but can be changed as necessary. 

Very basic text styling was also added: a placeholder sans-serif font is applied and line-height is set to 1.2

Colours were also tested for accessibility and pass AA guidelines. Can be changed in the future to pass AAA if stakeholders agree to it. See #41 for details.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

**Before:**
![image](https://github.com/user-attachments/assets/8dbc0ec3-1818-4c97-89cb-072e986d20bb)

**After:**
![image](https://github.com/user-attachments/assets/97158b4e-711f-420b-b0e4-531783e20a2d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched a refreshed user interface with a dynamic header featuring contact options, a streamlined navigation menu, and a poster overview section.
  - Introduced a dedicated memorial poster presentation with descriptive content and an actionable call-to-create custom posters.

- **Style**
  - Applied updated global design styles with refined color themes and responsive layout enhancements for optimal viewing across devices.

- **Documentation**
  - Added a public changelog to outline version details and notable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->