### PR TITLE
Added styles to LinkButton

### DIFF
--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -24,7 +24,7 @@
     transition-timing-function: ease-in-out;
 
     &:hover, 
-    &:focus {
+    &:focus-visible {
       background-color: var(--color-brown);
       color: var(--color-white);
       border: 2px solid var(--color-brown);

--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -9,15 +9,15 @@
 <style>
   a {
     display: inline-block;
-    text-align: center;
+    width: fit-content;
+    height: fit-content;
     padding: var(--spacing-xxs) var(--spacing-sm);
     border-radius: var(--border-radius-pill);
     border: 2px solid var(--color-brown-dark);
-    height: fit-content;
+    text-align: center;
     text-decoration: none;
-    color: var(--color-brown-dark);
     font-weight: var(--font-weight-bold);
-    width: fit-content;
+    color: var(--color-brown-dark);
 
     transition-property: border, background-color, color;
     transition-duration: 0.15s;

--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -10,8 +10,8 @@
   a {
     display: inline-block;
     text-align: center;
-    padding: 0.25rem 0.8rem;
-    border-radius: 3rem;
+    padding: var(--spacing-xxs) var(--spacing-sm);
+    border-radius: var(--border-radius-pill);
     border: 2px solid var(--color-brown-dark);
     height: fit-content;
     text-decoration: none;

--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -16,8 +16,19 @@
     height: fit-content;
     text-decoration: none;
     color: var(--color-brown-dark);
-    font-weight: bold;
+    font-weight: var(--font-weight-bold);
     width: fit-content;
+
+    transition-property: border, background-color, color;
+    transition-duration: 0.15s;
+    transition-timing-function: ease-in-out;
+
+    &:hover, 
+    &:focus {
+      background-color: var(--color-brown);
+      color: var(--color-white);
+      border: 2px solid var(--color-brown);
+    }
   }
 
   .full-width {

--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -30,8 +30,4 @@
       border: 2px solid var(--color-brown);
     }
   }
-
-  .full-width {
-    width: 100%;
-  }
 </style>

--- a/static/global.css
+++ b/static/global.css
@@ -2,9 +2,12 @@
   /*-----------------
         Colours
     -----------------*/
+
+  /* Base colours */
   --color-white: #fff;
   --color-black: #000;
 
+  /* Theme colours */
   --color-brown-light-fallback: #c29f9d;
   --color-brown-light: hsl(3 23.3% 68.8%);
 

--- a/static/global.css
+++ b/static/global.css
@@ -2,6 +2,9 @@
   /*-----------------
         Colours
     -----------------*/
+  --color-white: #fff;
+  --color-black: #000;
+
   --color-brown-light-fallback: #c29f9d;
   --color-brown-light: hsl(3 23.3% 68.8%);
 
@@ -39,6 +42,7 @@
   --border-radius-sm: 0.25rem;
   --border-radius-md: 0.5rem;
   --border-radius-lg: 1rem;
+  --border-radius-xl: 2rem;
   --border-radius-pill: 9999px;
 }
 

--- a/static/global.css
+++ b/static/global.css
@@ -66,6 +66,10 @@ div.query-container {
   container-type: inline-size;
 }
 
+  /*-----------------
+      Layout utils
+    -----------------*/
+
 .full-width {
   width: 100%;
 }

--- a/static/global.css
+++ b/static/global.css
@@ -62,3 +62,7 @@ body {
 div.query-container {
   container-type: inline-size;
 }
+
+.full-width {
+  width: 100%;
+}


### PR DESCRIPTION
## What does this change?

Resolves #39

Added some simple styling to the LinkButton to bring it more in line with button's styling on the original website. Added hover state, focus state, and made sure that the styling uses the design tokens in `global.css`.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

https://github.com/user-attachments/assets/36d871f4-faf8-45e5-8e43-4c1d4e89c9a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Stijl**
	- Verbeterde visuele interacties: knoppen tonen nu vloeiendere overgangen met duidelijke hover- en focus-effecten voor een responsievere gebruikersbeleving.
  
- **Nieuwe functies**
	- Extra ontwerpvariabelen zorgen voor consistente kleur- en afrondingsopties.
	- Een nieuwe utility-klasse maakt het mogelijk elementen over de volledige breedte van hun container weer te geven.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->