### PR TITLE
Added "rel" and "title" attributes to LinkButton

### DIFF
--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -1,8 +1,8 @@
 <script>
-  let { children, href, class: classList = "" } = $props();
+  let { children, href, class: classList = "", rel = "", title ="" } = $props();
 </script>
 
-<a {href} class={classList}>
+<a {href} class={classList} {rel} {title}>
   {@render children()}
 </a>
 

--- a/src/lib/organisms/Header.svelte
+++ b/src/lib/organisms/Header.svelte
@@ -6,10 +6,12 @@
 <header>
 	<img src="/assets/logo.avif" alt="4 Mei Comité Oosterparkbuurt" width="404" height="178" loading="eager"/>
 	<div class="header-mail-buttons">
-		<LinkButton class="full-width" href="mailto:4meioosterparkbuurt@gmail.com">contact</LinkButton>
+		<LinkButton class="full-width" href="mailto:4meioosterparkbuurt@gmail.com" rel="noopener" title="Contact via email">contact</LinkButton>
 		<LinkButton
 			class="full-width"
 			href="mailto:4meioosterparkbuurt@gmail.com?subject=Ik wil me abonneren op de nieuwsbrief"
+      rel="noopener"
+      title="Abonneer op nieuwsbrief"
 			>nieuwsbrief</LinkButton
 		>
 	</div>


### PR DESCRIPTION
## What does this change?

Resolves issue #49 

Added the capability for LinkButton to accept `rel` and `title` attributes, and made Header pass these to the LinkButtons inside.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## How to review

See LinkButton for implementation of rel and title props, then see Header for how these props are passed on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nieuwe functies**
  - Introductie van een geheel vernieuwde gebruikersinterface met een duidelijke header, navigatie en overzichtspagina voor gedenkposters.  
  - De pagina biedt dynamische presentatie van postergegevens, zoals naam, adres en geoptimaliseerde afbeeldingen, aangevuld met een informatieve introductiesectie.

- **Stijl & Design**
  - Invoering van een consistent, responsief ontwerp met vernieuwde typografie, kleurenschema en layoutverbeteringen voor zowel mobiele als desktopweergaven.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->