### PR TITLE
Added focus ring to NavItem

### DIFF
--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -27,8 +27,13 @@
     text-decoration: none;
     color: var(--color-brown-dark);
 
-    &:hover {
+    &:hover, &:focus-visible {
       text-decoration: underline;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-brown);
+      outline-offset: var(--spacing-xxs);
     }
   }
 </style>

--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -26,14 +26,16 @@
   a {
     text-decoration: none;
     color: var(--color-brown-dark);
+    transition: outline 0.15s ease-in-out;
+    outline: 0px solid var(--color-brown);
+    outline-offset: var(--spacing-xxs);
 
-    &:hover, &:focus-visible {
+    &:hover {
       text-decoration: underline;
     }
 
     &:focus-visible {
       outline: 3px solid var(--color-brown);
-      outline-offset: var(--spacing-xxs);
     }
   }
 </style>

--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -26,9 +26,9 @@
   a {
     text-decoration: none;
     color: var(--color-brown-dark);
-  }
 
-  a:hover {
-    text-decoration: underline;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 </style>

--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -32,7 +32,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid var(--color-brown);
+      outline: 3px solid var(--color-brown);
       outline-offset: var(--spacing-xxs);
     }
   }


### PR DESCRIPTION
## What does this change?

Resolves issue #70 

Added a focus ring to NavItem. Does not affect the hover state.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

![image](https://github.com/user-attachments/assets/af7bff28-8504-49fa-a690-1ce2523eea27)

## How to review

See NavItem for changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Stijl**
	- Verbeterde visuele feedback voor navigatielinks bij zowel muisinteractie als toetsenbordnavigatie. Links tonen nu een soepele overgang van de contour bij hover en focus-visible, wat de toegankelijkheid verhoogt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->