### PR TITLE
Added error state to PostersOverview component

### DIFF
--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -1,7 +1,7 @@
 <script>
 	import PosterCard from "../molecules/PosterCard.svelte";
 
-	let { posters } = $props();
+	let { posters = "" } = $props();
 </script>
 
 {#if posters.length === 0}

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -4,9 +4,7 @@
 	let { posters = "" } = $props();
 </script>
 
-{#if posters.length === 0}
-  <p>Geen posters gevonden</p>
-{:else}
+{#if posters == typeof Array && posters.length == 0}
 	<ul>
 		{#each posters as posterData}
 			<PosterCard
@@ -17,6 +15,8 @@
 			/>
 		{/each}
 	</ul>
+{:else}
+	<p>Geen posters gevonden</p>
 {/if}
 
 <style>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -1,5 +1,5 @@
 <script>
-	import PosterCard from '../molecules/PosterCard.svelte';
+	import PosterCard from "../molecules/PosterCard.svelte";
 
 	let { posters } = $props();
 </script>
@@ -10,10 +10,10 @@
 	<ul>
 		{#each posters as posterData}
 			<PosterCard
-				name={posterData.family.family_name ?? 'Onbekend'}
-				street={posterData.street ?? 'Onbekend'}
-				house_number={posterData.house_number ?? 'Onbekend'}
-				image={posterData.poster.covers[1].directus_files_id ?? ''}
+				name={posterData.family.family_name ?? "Onbekend"}
+				street={posterData.street ?? "Onbekend"}
+				house_number={posterData.house_number ?? "Onbekend"}
+				image={posterData.poster.covers[1].directus_files_id ?? ""}
 			/>
 		{/each}
 	</ul>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -1,10 +1,10 @@
 <script>
 	import PosterCard from "../molecules/PosterCard.svelte";
 
-	let { posters = "" } = $props();
+	let { posters = [] } = $props();
 </script>
 
-{#if posters != typeof String && posters.length > 0}
+{#if posters.length > 0}
 	<ul>
 		{#each posters as posterData}
 			<PosterCard

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -4,7 +4,7 @@
 	let { posters = "" } = $props();
 </script>
 
-{#if posters == typeof Array && posters.length == 0}
+{#if posters != typeof String && posters.length > 0}
 	<ul>
 		{#each posters as posterData}
 			<PosterCard

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -16,7 +16,7 @@
 		{/each}
 	</ul>
 {:else}
-	<p>Geen posters gevonden</p>
+	<p>Er zijn momenteel geen posters beschikbaar. Kom later terug of neem contact met ons op via de knop bovenin de pagina als dit probleem aanhoudt.</p>
 {/if}
 
 <style>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -4,16 +4,20 @@
 	let { posters } = $props();
 </script>
 
-<ul>
-	{#each posters as posterData}
-		<PosterCard
-			name={posterData.family.family_name ?? "Onbekend"}
-			street={posterData.street ?? "Onbekend"}
-			house_number={posterData.house_number ?? "Onbekend"}
-			image={posterData.poster.covers[1].directus_files_id ?? ""}
-		/>
-	{/each}
-</ul>
+{#if posters.length === 0}
+  <p>Geen posters gevonden</p>
+{:else}
+	<ul>
+		{#each posters as posterData}
+			<PosterCard
+				name={posterData.family.family_name ?? 'Onbekend'}
+				street={posterData.street ?? 'Onbekend'}
+				house_number={posterData.house_number ?? 'Onbekend'}
+				image={posterData.poster.covers[1].directus_files_id ?? ''}
+			/>
+		{/each}
+	</ul>
+{/if}
 
 <style>
 	ul {


### PR DESCRIPTION
## What does this change?

Resolves issue #69 

Added error handling to the PostersOverview component, along with a simple error state which tells the user that no posters could be found.

## Images

![image](https://github.com/user-attachments/assets/442d02b2-8095-4fb5-a74f-a3c2437fec5b)

## How to review

See PostersOverview for all changes. Pass an empty prop to PostersOverview to see the error state during testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nieuwe functies**
	- Gebruikers ontvangen nu een duidelijke melding ("Er zijn momenteel geen posters beschikbaar. Kom later terug of neem contact met ons op via de knop bovenin de pagina als dit probleem aanhoudt.") wanneer er geen posters beschikbaar zijn.

- **Refactor**
	- De weergavelogica van posters is geoptimaliseerd voor betere foutafhandeling en gebruikservaring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->