### PR TITLE
Improved fetch request error handling

### DIFF
--- a/src/lib/directus.js
+++ b/src/lib/directus.js
@@ -1,8 +1,8 @@
-import { createDirectus, rest } from '@directus/sdk';
+import { createDirectus, rest } from "@directus/sdk";
 
 function getDirectusInstance(fetch) {
 	const options = fetch ? { globals: { fetch } } : {};
-	const directus = createDirectus('https://fdnd-agency.directus.app', options).with(rest());
+	const directus = createDirectus("https://fdnd-agency.directus.app", options).with(rest());
 	return directus;
 }
 

--- a/src/routes/+page.js
+++ b/src/routes/+page.js
@@ -1,29 +1,32 @@
-import getDirectusInstance from "$lib/directus";
-import { readItems } from "@directus/sdk";
+import getDirectusInstance from '$lib/directus';
+import { readItems } from '@directus/sdk';
 export async function load({ fetch }) {
-	const directus = getDirectusInstance(fetch);
-	return {
-		posters: await directus.request(
-			readItems("atlas_address", {
-				fields: [
-					"id",
-					"street",
-					"house_number",
-          {
-            family: [
-              "family_name",
-            ]
-          },
-					{
-						poster: [
-							"id",
-							{
-								covers: ["directus_files_id"]
-							}
-						]
-					},
-				]
-			})
-		)
-	};
+	try {
+		const directus = getDirectusInstance(fetch);
+		return {
+			posters: await directus.request(
+				readItems('atlas_address', {
+					fields: [
+						'id',
+						'street',
+						'house_number',
+						{
+							family: ['family_name']
+						},
+						{
+							poster: [
+								'id',
+								{
+									covers: ['directus_files_id']
+								}
+							]
+						}
+					]
+				})
+			)
+		};
+	} catch (error) {
+		console.error(error);
+		return {}; // Return empty object if error;
+	}
 }


### PR DESCRIPTION
## What does this change?

Resolves #69 

Improved the error handling in the data fetching process by catching errors earlier and making sure that an empty object is passed to the page should an error occur. This way if the fetch request fails only the parts dependent on it will show an error state, while the rest of the page still renders normally.

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

## How to review

Try changing the URL in directus.js to force a failed fetch request for testing the new error handling
