### PR TITLE
Colours converted to OKLCH colourspace

### DIFF
--- a/src/lib/atoms/Debug.svelte
+++ b/src/lib/atoms/Debug.svelte
@@ -13,8 +13,8 @@
 
 <style>
 	div {
-    background: linear-gradient(150deg, var(--color-brown-light) 0%, var(--color-brown) 100%);
-    border: 1px var(--color-brown-dark) solid;
+    background: linear-gradient(150deg, var(--brown-light) 0%, var(--brown-neutral) 100%);
+    border: 1px var(--brown-dark) solid;
 		height: 100%;
 		width: 100%;
 		overflow: hidden;

--- a/src/lib/atoms/Divider.svelte
+++ b/src/lib/atoms/Divider.svelte
@@ -7,6 +7,6 @@
 <style>
 	hr {
 		border-top: 0;
-		border-bottom: 1px solid black;
+		border-bottom: 1px solid var(--brown-dark);
 	}
 </style>

--- a/src/lib/atoms/LinkButton.svelte
+++ b/src/lib/atoms/LinkButton.svelte
@@ -1,8 +1,8 @@
 <script>
-  let { children, href, class: classList = "", rel = "", title ="" } = $props();
+  let { children, href, class: classList = "" } = $props();
 </script>
 
-<a {href} class={classList} {rel} {title}>
+<a {href} class="no-focus {classList}">
   {@render children()}
 </a>
 
@@ -13,11 +13,11 @@
     height: fit-content;
     padding: var(--spacing-xxs) var(--spacing-sm);
     border-radius: var(--border-radius-pill);
-    border: 2px solid var(--color-brown-dark);
+    border: 2px solid var(--brown-dark);
     text-align: center;
     text-decoration: none;
     font-weight: var(--font-weight-bold);
-    color: var(--color-brown-dark);
+    color: var(--brown-dark);
 
     transition-property: border, background-color, color;
     transition-duration: 0.15s;
@@ -25,9 +25,9 @@
 
     &:hover, 
     &:focus-visible {
-      background-color: var(--color-brown);
-      color: var(--color-white);
-      border: 2px solid var(--color-brown);
+      background-color: var(--brown-neutral);
+      color: var(--white);
+      border: 2px solid var(--brown-neutral);
     }
   }
 </style>

--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -20,15 +20,19 @@
 
   span[aria-current="page"] {
     font-size: 1rem;
-    color: var(--color-brown);
+    color: var(--orange-neutral);
   }
 
   a {
     text-decoration: none;
-    color: var(--color-brown-dark);
+    color: var(--brown-dark);
 
     &:hover {
       text-decoration: underline;
+    }
+
+    &:focus-visible {
+      border-radius: var(--border-radius-pill);
     }
   }
 </style>

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -16,7 +16,7 @@
 <style>
 	a {
 		text-decoration: none;
-		color: var(--color-brown-dark);
+		color: var(--brown-dark);
 	}
 
 	li {

--- a/static/global.css
+++ b/static/global.css
@@ -4,19 +4,35 @@
     -----------------*/
 
   /* Base colours */
-  --color-white: #fff;
-  --color-black: #000;
+  --white: #fff;
+  --black: #000;
+
+  /* Base CH values */
+  --orange-c: 0.1702;
+  --orange-h: 31.76;
+
+  --brown-c: 0.0814;
+  --brown-h: 36;
+
+  /* Ligntness variations */
+  --darkest: 15%;
+  --dark: 30%;
+  --neutral: 50%; 
+  --light: 70%;
+  --lightest: 90%;
 
   /* Theme colours */
-  --color-brown-light-fallback: #c29f9d;
-  --color-brown-light: hsl(3 23.3% 68.8%);
+  --orange-darkest: oklch(var(--darkest) var(--orange-c) var(--orange-h));
+  --orange-dark: oklch(var(--dark) var(--orange-c) var(--orange-h));
+  --orange-neutral: oklch(var(--neutral) var(--orange-c) var(--orange-h));
+  --orange-light: oklch(var(--light) var(--orange-c) var(--orange-h));
+  --orange-lightest: oklch(var(--lightest) var(--orange-c) var(--orange-h));
 
-  --color-brown-fallback: #a34a21;
-  --color-brown: hsl(19 66.3% 38.4%);
-
-  --color-brown-dark-fallback: #3e2518;
-  --color-brown-dark: hsl(21 44.2% 16.9%);
-
+  --brown-darkest: oklch(var(--darkest) var(--brown-c) var(--brown-h));
+  --brown-dark: oklch(var(--dark) var(--brown-c) var(--brown-h));
+  --brown-neutral: oklch(var(--neutral) var(--brown-c) var(--brown-h));
+  --brown-light: oklch(var(--light) var(--brown-c) var(--brown-h));
+  --brown-lightest: oklch(var(--lightest) var(--brown-c) var(--brown-h));
 
   --max-width-mobile: 400px;
   --max-width-desktop: 800px;
@@ -61,7 +77,7 @@ body {
   font-style: normal;
   font-size: 16px;
   line-height: 1.2;
-  color: var(--color-brown-dark);
+  color: var(--brown-dark);
 }
 
 div.query-container {
@@ -82,11 +98,11 @@ div.query-container {
 
 .focus-ring {
   transition: outline 0.15s ease-in-out;
-  outline: 0px solid var(--color-brown);
+  outline: 0px solid var(--brown-neutral);
   outline-offset: var(--spacing-xxs);
 
   &:focus-visible, &:focus-within {
-    outline: 3px solid var(--color-brown);
+    outline: 3px solid var(--brown-neutral);
   }
 }
 


### PR DESCRIPTION
## What does this change?

Resolves #80, #81

Refactored all the HSL colours to the OKLCH colour space and made a better, more flexible palette. Also changed components using the colours to use the new palette. 

### Colour contrasts used on page are WCAG AA compliant:
- **brown-dark : white**
  14.04:1

- **brown-neutral : white**
  6.17 : 1

- **orange-neutral : white**
  6.53:1

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [x] Browser test

## Images

![image](https://github.com/user-attachments/assets/a6bb705d-8b19-4984-afd5-7b15f72d325f)

## How to review

See global.css on how the colour palette is implemented. Then see the components on how these colours are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Bijgewerkte achtergrondgradients, randkleuren en tekstkleuren voor een uniform uiterlijk.
  - Verbeterde focus- en hover-effecten op navigatie-elementen, scheidingslijnen en knoppen.
  - Een modern kleurenschema met nieuwe oranje- en bruintinten zorgt voor een consistente visuele ervaring.

- **Refactor**
  - Vereenvoudigde koppelingseigenschappen voor een strakkere en consistente interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->