### PR TITLE
Feature detail page setup

### DIFF
--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Image from "$lib/atoms/DirectusImage.svelte"
+	import DirectusImage from "$lib/atoms/DirectusImage.svelte"
 
 	let { name, street, house_number, floor, addition, image, width, height } = $props()
 
@@ -34,7 +34,7 @@
 <li class="focus-ring {orientation}">
   <!-- no-focus is added so that the default focus ring is hidden and does not conflict with the custom style-->
 	<a href="/" class="no-focus">
-    <Image imageId={image} {width} {height} alt="Gedenkposter van {name}" loading="lazy"/>
+    <DirectusImage imageId={image} {width} {height} alt="Gedenkposter van {name}" loading="lazy"/>
 		<p class="name">Familie {name}</p>
 		<p>{street} {house_number} {floor} {addition}</p>
 	</a>

--- a/src/routes/poster/[slug]/+page.server.js
+++ b/src/routes/poster/[slug]/+page.server.js
@@ -1,0 +1,43 @@
+import getDirectusInstance from '$lib/directus';
+import { readItems } from '@directus/sdk';
+export async function load({ fetch, params }) {
+	try {
+		const directus = getDirectusInstance(fetch);
+		return {
+			poster: await directus.request(
+				readItems('atlas_address', {
+          filter: {
+            slug: {
+              _eq: params.slug
+            },
+          },
+					fields: [
+						'id',
+						'street',
+						'house_number',
+						'floor',
+						'addition',
+						{
+							person: ['first_name', 'last_name']
+						},
+						{
+							poster: [
+								'id',
+								{
+									covers: [
+										'directus_files_id.id',
+										'directus_files_id.width',
+										'directus_files_id.height'
+									]
+								}
+							]
+						}
+					]
+				})
+			)
+		};
+	} catch (error) {
+		console.error(error);
+		return {}; // Return empty object if error
+	}
+}

--- a/src/routes/poster/[slug]/+page.svelte
+++ b/src/routes/poster/[slug]/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+	import DirectusImage from '$lib/atoms/DirectusImage.svelte';
+
+	const { data } = $props();
+	const { street, house_number, floor, addition, person, poster } = data.poster[0];
+	console.log(person);
+</script>
+
+<h1>{street} {house_number} {addition} {floor}</h1>
+
+{#each poster.covers as image}
+	<DirectusImage
+		imageId={image.directus_files_id.id}
+		width={image.directus_files_id.width}
+		height={image.directus_files_id.height}
+		alt="Gedenkposter van {street} {house_number} {addition} {floor}}"
+	/>
+{/each}
+
+{#each person as person}
+    <h2>{person.first_name} {person.last_name}</h2>
+{/each}


### PR DESCRIPTION
## What does this change?

Resolves #113

## Images

Added basic setup for the details page which simply displays the (currently quite limited) available information for a given poster. Only core functionality is done, no styling applied yet.

Also did a small code style change in PosterCard for better consistency.

## How to review

See the small code style change in PosterCard first. Then, open `src/routes/poster/[slug]/+page.server.js` to see the fetch request which gathers the available data for the given poster. Last, see the page itself at `src/routes/poster/[slug]/+page.svelte`
