### PR TITLE
Fixed error handling in PostersOverview

### DIFF
--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -13,9 +13,9 @@
 				house_number={posterData.house_number ?? "Onbekend"}
 				floor={posterData?.floor}
 				addition={posterData?.addition}
-				image={posterData.poster ? posterData.poster.covers[0].directus_files_id.id : ""}
-				width={posterData.poster ? posterData.poster.covers[0].directus_files_id.width: 419}
-				height={posterData.poster ? posterData.poster.covers[0].directus_files_id.height : 585}
+				image={posterData.poster?.covers?.[0]?.directus_files_id?.id ?? ""}
+				width={posterData.poster?.covers?.[0]?.directus_files_id?.width ?? 419}
+				height={posterData.poster?.covers?.[0]?.directus_files_id?.height ?? 585}
 			/>
 		{/each}
 	</ul>


### PR DESCRIPTION
## What does this change?

Resolves #103 

Changed error handling of images in PostersOverview to be more robust. Previously not having an image would crash the site because the error handling code would try to access null fields, which should now be fixed.

## How Has This Been Tested?

- [x] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [x] Browser test

## How to review

See PostersOverview for all changes
