### PR TITLE
Remade overview grid

### DIFF
--- a/src/lib/atoms/Button.svelte
+++ b/src/lib/atoms/Button.svelte
@@ -32,7 +32,7 @@
 		text-decoration: none;
 		/* font-weight: var(--font-weight-bold); */
 		color: var(--neutral-900);
-    background-color: transparent;
+    background-color: var(--white);
     cursor: pointer;
     font-size: 1rem;
 

--- a/src/lib/atoms/NavItem.svelte
+++ b/src/lib/atoms/NavItem.svelte
@@ -33,12 +33,9 @@
     color: var(--neutral-900);
     font-weight: var(--font-weight-regular);
 
-    &:hover {
-      text-decoration: underline;
-    }
-
+    &:hover,
     &:focus-visible {
-      border-radius: var(--border-radius-pill);
+      text-decoration: underline;
     }
   }
 

--- a/src/lib/molecules/FilterNaam.svelte
+++ b/src/lib/molecules/FilterNaam.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <FilterCard>
-	<TextInput id="naam" placeholder="Vries..." {onchange}>
+	<TextInput id="naam" placeholder="Jacob..." {onchange}>
 		Naam
 	</TextInput>
 </FilterCard>

--- a/src/lib/molecules/FilterNaam.svelte
+++ b/src/lib/molecules/FilterNaam.svelte
@@ -1,11 +1,19 @@
 <script>
 	import TextInput from '$lib/atoms/TextInput.svelte';
 	import FilterCard from '$lib/atoms/FilterCard.svelte';
+	import { page } from '$app/state';
+
+	let name = $state('');
+
+	if (page.url.searchParams.get('naam')) {
+		$effect(() => {
+			name = page.url.searchParams.get('naam');
+		});
+	}
+
 	let { onchange } = $props();
 </script>
 
 <FilterCard>
-	<TextInput id="naam" placeholder="Jacob..." {onchange}>
-		Naam
-	</TextInput>
+	<TextInput id="naam" placeholder="Jacob..." {onchange} value={name}>Naam</TextInput>
 </FilterCard>

--- a/src/lib/molecules/FilterStraat.svelte
+++ b/src/lib/molecules/FilterStraat.svelte
@@ -1,11 +1,18 @@
 <script>
 	import TextDropdownInput from '$lib/atoms/TextDropdownInput.svelte';
 	import FilterCard from "$lib/atoms/FilterCard.svelte";
-	
   import { page } from '$app/state';
   
-	let { onchange } = $props();
+  let street = $state('');
 
+  if (page.url.searchParams.get('straat')) {
+    $effect(() => {
+      street = page.url.searchParams.get('straat');
+    });
+  }
+
+	let { onchange } = $props();
+  
 	let streetsList = $derived(
 		Array.from(
 			// Remove duplicates
@@ -23,6 +30,7 @@
 		placeholder="Oosterpark..."
 		list={streetsList}
 		{onchange}
+		value={street}
 	>
 		Straat
 	</TextDropdownInput>

--- a/src/lib/molecules/Logout.svelte
+++ b/src/lib/molecules/Logout.svelte
@@ -6,7 +6,7 @@
 
 {#if isAuthenticated}
 <form method="POST" action="/logout">
-  <Button type="submit" style="background-color: var(--white);">Logout</Button>
+  <Button type="submit">Logout</Button>
 </form>
 {/if}
 

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -31,13 +31,15 @@
 <style>
 	a {
 		text-decoration: none;
-		color: var(--brown-dark);
+		color: var(--neutral-900);
 	}
 
 	li {
 		list-style-type: none;
 		display: block;
 		width: 100%;
+    padding: var(--spacing-xs);
+    border-radius: var(--border-radius-md);
 	}
 
 	@media screen and (min-width: 800px) {
@@ -54,19 +56,15 @@
 	}
   
 	.focus-ring {
-		transition: 0.15s ease-in-out;
-		outline: 0px solid var(--brown-neutral);
-		outline-offset: var(--spacing-xxs);
+		transition: 0.15s ease-in;
+		outline: 0px solid var(--brown-400);
+		outline-offset: 0px;
 
-		&:hover,&:focus-visible, &:focus-within {
-			outline: none;
-			background:var(--brown-neutral);
-			padding:.5rem;
-			border-radius:var(--border-radius-md);
-
-			p {
-				color:var(--white);
-			}
+		&:hover, 
+    &:focus-visible,
+    &:focus-within {
+			outline: 2px solid var(--brown-400);
+			background: var(--brown-100);
 		}
 	}
 </style>

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <li class="focus-ring {orientation}">
-  <!-- no-focus is added so that the default focus ring is hidden and does not conflict with the custom style-->
+  <!-- no-focus is added so that the default focus ring is hidden and does not conflict with the custom style -->
 	<a href="/" class="no-focus">
     <DirectusImage imageId={image} {width} {height} alt="Gedenkposter van {name}" loading="lazy"/>
 		<p class="name">Familie {name}</p>
@@ -57,10 +57,12 @@
 			grid-column: span 2;
 		}
   }
-
+  
 	p.name {
-		margin-top: 0.25rem;
-    font-weight: var(--font-weight-bold);
+    margin-top: 0.25rem;
+    font-size: var(--font-size-lg);
+    font-family: var(--font-family-fraunces);
+    font-weight: var(--font-weight-medium);
 	}
 
 	.focus-ring {

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -41,12 +41,6 @@
     padding: var(--spacing-xs);
     border-radius: var(--border-radius-md);
 	}
-
-	@media screen and (min-width: 800px) {
-		li.landscape {
-			grid-column: span 2;
-		}
-  }
   
 	p.name {
     margin-top: 0.25rem;

--- a/src/lib/molecules/PosterCard.svelte
+++ b/src/lib/molecules/PosterCard.svelte
@@ -1,5 +1,6 @@
 <script>
 	import DirectusImage from "$lib/atoms/DirectusImage.svelte"
+  import toRomanNumerals from "$lib/utils/toRomanNumerals"
 
 	let { name, street, house_number, floor, addition, image, width, height } = $props()
 
@@ -15,20 +16,7 @@
 		height = 585
 	}
 	
-	floor = floor ? toRoman(floor) : ''
-
-	function toRoman(floor) {
-		switch (floor) {
-			case 1:
-				return 'I'
-			case 2:
-				return 'II'
-			case 3:
-				return 'III'
-			default:
-				return ''
-		}
-	}
+	floor = floor ? toRomanNumerals(floor) : ''
 </script>
 
 <li class="focus-ring {orientation}">
@@ -64,7 +52,7 @@
     font-family: var(--font-family-fraunces);
     font-weight: var(--font-weight-medium);
 	}
-
+  
 	.focus-ring {
 		transition: 0.15s ease-in-out;
 		outline: 0px solid var(--brown-neutral);
@@ -80,6 +68,5 @@
 				color:var(--white);
 			}
 		}
-
 	}
 </style>

--- a/src/lib/organisms/Header.svelte
+++ b/src/lib/organisms/Header.svelte
@@ -2,7 +2,7 @@
 	import Button from '$lib/atoms/Button.svelte';
 	import Nav from '$lib/molecules/Nav.svelte';
 	import NavItem from '$lib/atoms/NavItem.svelte';
-	import { getCurrentPage } from '$lib/utils/getCurrentPage';
+	import getCurrentPage from '$lib/utils/getCurrentPage';
 
   import { page } from '$app/state';
 

--- a/src/lib/organisms/PostersFilter.svelte
+++ b/src/lib/organisms/PostersFilter.svelte
@@ -2,29 +2,41 @@
 	import FilterNaam from '$lib/molecules/FilterNaam.svelte';
 	import FilterStraat from '$lib/molecules/FilterStraat.svelte';
 	import Button from '$lib/atoms/Button.svelte';
-  import { onMount } from 'svelte';
+	import { onMount } from 'svelte';
 
 	let form;
-  let javascriptEnabled;
+	let javascriptEnabled;
 
 	function filterHandler(event) {
 		form.requestSubmit();
 	}
 
-  onMount(() => {
-    javascriptEnabled = true;
-  });
+	onMount(() => {
+		javascriptEnabled = true;
+	});
 </script>
 
 <form bind:this={form} action="/posters" data-sveltekit-noscroll>
-			<FilterNaam onchange={filterHandler} />
-			<FilterStraat onchange={filterHandler} />
-			<Button class={(javascriptEnabled ? "sr-only" : '')} type="submit">Toepassen</Button>
+	<FilterNaam onchange={filterHandler} />
+	<FilterStraat onchange={filterHandler} />
+	<Button class={javascriptEnabled ? 'sr-only' : ''} buttonClass={$css("show-on-focus")} type="submit">Toepassen</Button>
 </form>
 
 <style>
 	form {
 		display: flex;
 		gap: var(--spacing-xs);
+	}
+
+	.show-on-focus:focus-visible {
+		position: static;
+		display: inline-block;
+		width: fit-content;
+		height: fit-content;
+		padding: var(--spacing-xxs) var(--spacing-sm);
+		overflow: visible;
+		clip: auto;
+		white-space: normal;
+		border-width: 0;
 	}
 </style>

--- a/src/lib/organisms/PostersFilter.svelte
+++ b/src/lib/organisms/PostersFilter.svelte
@@ -25,8 +25,16 @@
 <style>
 	form {
 		display: flex;
+		flex-direction: column;
 		gap: var(--spacing-xs);
 	}
+
+  @media screen and (min-width: 800px) {
+    form {
+      flex-direction: row;
+      gap: var(--spacing-md);
+    }
+  }
 
 	.show-on-focus:focus-visible {
 		position: static;

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -47,7 +47,7 @@
 	ul {
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-		gap: 2rem;
+		gap: var(--spacing-sm);
 		padding-top: 3rem;
 	}
 

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -56,4 +56,10 @@
 		justify-content: space-between;
 		align-items: center;
 	}
+
+  @media screen and (min-width: 800px) {
+		div:global(:has(.landscape)) {
+			grid-column: span 2;
+		}
+  }
 </style>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -1,6 +1,8 @@
 <script>
 	import PosterCard from '../molecules/PosterCard.svelte';
 	import PostersFilter from '$lib/organisms/PostersFilter.svelte';
+	import { flip } from "svelte/animate";
+  import { fade } from "svelte/transition";
 
 	let { posters = [] } = $props();
 </script>
@@ -15,7 +17,8 @@
 {:then posters}
 	{#if posters.length > 0}
 		<ul>
-			{#each posters as posterData}
+			{#each posters as posterData (posterData.id)}
+      <div transition:fade={{duration: 200}} animate:flip={{duration: 200}}>
 				<PosterCard
 					name={posterData.person?.[0]?.last_name ?? 'Onbekend'}
 					street={posterData.street ?? 'Onbekend'}
@@ -26,6 +29,7 @@
 					width={posterData.poster?.covers?.[0]?.directus_files_id?.width ?? 419}
 					height={posterData.poster?.covers?.[0]?.directus_files_id?.height ?? 585}
 				/>
+      </div>
 			{/each}
 		</ul>
 	{:else}

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -35,8 +35,7 @@
 		</ul>
 	{:else}
 		<p>
-			Er zijn momenteel geen posters beschikbaar. Kom later terug of neem contact met ons op via de
-			knop bovenin de pagina als dit probleem aanhoudt.
+		  Geen posters gevonden. Probeer de filters te wijzigen, of probeer het later opnieuw.
 		</p>
 	{/if}
 {:catch error}
@@ -50,6 +49,10 @@
 		gap: var(--spacing-sm);
 		padding-top: var(--spacing-sm);
 	}
+
+  p {
+    padding-top: var(--spacing-lg);
+  }
 
 	header {
 		display: flex;

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -48,18 +48,30 @@
 		display: grid;
 		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 		gap: var(--spacing-sm);
-		padding-top: 3rem;
+		padding-top: var(--spacing-sm);
 	}
 
 	header {
 		display: flex;
-		justify-content: space-between;
+    gap: var(--spacing-md);
+		flex-direction: column;
 		align-items: center;
 	}
-
+  
   @media screen and (min-width: 800px) {
-		div:global(:has(.landscape)) {
-			grid-column: span 2;
+    div:global(:has(.landscape)) {
+      grid-column: span 2;
 		}
+  }
+  
+  @media screen and (min-width: 940px) {
+    header {
+      flex-direction: row;
+      justify-content: space-between;
+    }
+    
+    ul {
+      padding-top: var(--spacing-lg);
+    }
   }
 </style>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -3,6 +3,7 @@
 	import PostersFilter from '$lib/organisms/PostersFilter.svelte';
 	import { flip } from "svelte/animate";
   import { fade } from "svelte/transition";
+	import { cubicOut } from "svelte/easing";
 
 	let { posters = [] } = $props();
 </script>
@@ -18,7 +19,7 @@
 	{#if posters.length > 0}
 		<ul>
 			{#each posters as posterData (posterData.id)}
-      <div transition:fade={{duration: 200}} animate:flip={{duration: 200}}>
+      <div transition:fade={{duration: 300, easing: cubicOut}} animate:flip={{duration: 300, easing: cubicOut}}>
 				<PosterCard
 					name={posterData.person?.[0]?.last_name ?? 'Onbekend'}
 					street={posterData.street ?? 'Onbekend'}

--- a/src/lib/utils/getCurrentPage.js
+++ b/src/lib/utils/getCurrentPage.js
@@ -1,4 +1,4 @@
-export function getCurrentPage(pageURL) {
+export default function getCurrentPage(pageURL) {
   switch (pageURL) {
     case '/':
       console.log("home");

--- a/src/lib/utils/toRomanNumerals.js
+++ b/src/lib/utils/toRomanNumerals.js
@@ -1,0 +1,12 @@
+export default function toRomanNumerals(floor) {
+  switch (floor) {
+    case 1:
+      return 'I'
+    case 2:
+      return 'II'
+    case 3:
+      return 'III'
+    default:
+      return ''
+  }
+}

--- a/static/global.css
+++ b/static/global.css
@@ -178,11 +178,11 @@ div.query-container {
 
 .focus-ring {
   transition: outline 0.15s ease-in-out;
-  outline: 0px solid var(--brown-neutral);
+  outline: 0px solid var(--brown-400);
   outline-offset: var(--spacing-xxs);
 
   &:focus-visible, &:focus-within {
-    outline: 3px solid var(--brown-neutral);
+    outline: 3px solid var(--brown-400);
   }
 }
 


### PR DESCRIPTION
## What does this change?

Resolves issues:
- #121
- #123 
- #136
- #86 
- #137
- #138
- #139

This PR was mostly focused on implementing a redesigned and improved overview grid. To achieve this, I did the following:
- Added some animations when filtering using Svelte's built-in `animate` and `transition` directives
- Made the placeholder for the Naam filter a more common and intuitive name
- Changed font on names in FilterCard
- Tweaked grid gap in overview grid
- Fixed landscape orientations
- Made the filter submit button show when focused
- Improved the responsiveness of overview grid
- Made search bars persist state through refresh
- Improved the zero state of the grid to be more descriptive
- Changed the hover on PosterCard to be slightly more subtle

And I also implemented some miscellaneous improvements:
- Refactored the toRoman function into a utils import
- Fixed styling on logout button
- Fixed focus states using deprecated colour names

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

**Before:**
![image](https://github.com/user-attachments/assets/14fb5cef-57a9-4db5-8953-d23b0a51b9b7)

**After:**
![image](https://github.com/user-attachments/assets/f2689b65-f46c-40b6-a74b-b0e0985cfbdf)
